### PR TITLE
Fixed revisits bug where preexisting cdx revisit fields overwritten with blanks

### DIFF
--- a/pywb/warcserver/index/cdxops.py
+++ b/pywb/warcserver/index/cdxops.py
@@ -325,6 +325,9 @@ def cdx_resolve_revisits(cdx_iter):
     originals = {}
 
     for cdx in cdx_iter:
+        if all([cdx.get('orig.' + field) for field in ORIG_TUPLE]):
+            yield cdx
+            continue
         is_revisit = cdx.is_revisit()
 
         digest = cdx.get(DIGEST)


### PR DESCRIPTION
## Description
If you use CDX11+3 format (which includes the three revisit resolved fields), the values are overwritten with 3 dashes if the revisit can't be resolved in the context of the current query.  This hot fix checks for the presence of the 3 revisit fields before attempting to resolve.  If they already exist, we yield the row unaltered.

## Motivation and Context
CDX11+3 format orig fields don't need to be resolved.  We can return these rows as-is to avoid two possible side affects: 1. Unnecessary overhead in trying to resolve the originals on-the-fly. 2. Unmatched CDX resolutions (for any reason out of the context of the current CDX query set) result in the values being stripped.

## Types of changes
- [x] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)